### PR TITLE
呼び出した useRouter を使用していなかったため修正

### DIFF
--- a/contents/blogPost/why-use-server-actions.md
+++ b/contents/blogPost/why-use-server-actions.md
@@ -118,6 +118,7 @@ import { useRouter } from "next/router";
 
 function Form() {
   const [tweet, setTweet] = useState("");
+  const router = useRouter();
 
   const handleSubmit = async (event) => {
     event.preventDefault();


### PR DESCRIPTION
```js
import { useRouter } from "next/router"; // useRouter が import されているが使用されていない
 
function Form() {
  const [tweet, setTweet] = useState("");
 
  const handleSubmit = async (event) => {
    event.preventDefault();
    await fetch("/api/tweet", {
      method: "POST",
      body: JSON.stringify({ tweet }),
    });
    router.push("/home"); // useRouter から呼び出されていない
  };
 
  return (
    <form onSubmit={handleSubmit}>
      <input
        type="text"
        value={tweet}
        onChange={(event) => setTweet(event.target.value)}
      />
      <button type="submit" disabled={isSubmitting}>
        Tweet
      </button>
    </form>
  );
}
```
上記サンプルコード内で useRouter が呼び出されつつも router として使用されていなかったためコード内修正しました