### PR TITLE
誤植修正：コール場アク関数　-> コールバック関数

### DIFF
--- a/contents/blogPost/full-stack-web-framework-honox.md
+++ b/contents/blogPost/full-stack-web-framework-honox.md
@@ -115,7 +115,7 @@ export default createRoute((c) => {
 })
 ```
 
-HonoX ではそれぞれのルートで `Handler | MiddlewareHandler` の配列を `default export` する必要があります。`createRoute` はそのためのヘルパー関数です。`createRoute` に渡すコール場アク関数では引数として `Context` を受け取ります。これは [Hono の Context](https://hono.dev/api/context) と同じです。ここでは `c.req.query('name')` でクエリパラメータを取得しています。
+HonoX ではそれぞれのルートで `Handler | MiddlewareHandler` の配列を `default export` する必要があります。`createRoute` はそのためのヘルパー関数です。`createRoute` に渡すコールバック関数では引数として `Context` を受け取ります。これは [Hono の Context](https://hono.dev/api/context) と同じです。ここでは `c.req.query('name')` でクエリパラメータを取得しています。
 
 `c.render` 関数を使ってコンポーネントをレンダリングしています。ここで使われているのは HonoX のデフォルトのレンダリングエンジンである [hono/jsx](https://hono.dev/guides/jsx) です。基本的には React と同じように使えます。
 


### PR DESCRIPTION
### 誤植修正

#### 修正内容
- ブログ記事「フルスタック Web フレームワーク HonoX を使ってみる」における誤植を修正しました。
  - 誤: "`createRoute` に渡すコール場アク関数では引数として `Context` を受け取ります。"
  - 正: "`createRoute` に渡すコールバック関数では引数として `Context` を受け取ります。"

#### 修正理由
- 誤植のため。

#### 影響範囲
- この修正による機能的な変更はありません。
