### PR TITLE
Fixed a missing space before a list item bullet point

### DIFF
--- a/contents/blogPost/web-accessibility-basics-every-web-application-engineer-needs-to-know.md
+++ b/contents/blogPost/web-accessibility-basics-every-web-application-engineer-needs-to-know.md
@@ -430,7 +430,7 @@ https://www.w3.org/WAI/ARIA/apg/patterns/
 UI ライブラリを選定する際には、WAI-ARIA の仕様に従った実装をしているかどうかを基準の 1 つとすると良いでしょう。以下に上げる UI ライブラリはスタイルを除いてアクセシビリティの機能のみを提供しているのでおすすめです。見た目のカスタマイズを容易に行えるので、デザインシステムとして組み込みやすいです。
 
 - [Primitives – Radix UI](https://www.radix-ui.com/)
--[Headless UI - Unstyled, fully accessible UI components](https://headlessui.com/)
+- [Headless UI - Unstyled, fully accessible UI components](https://headlessui.com/)
 - [Reach UI](https://reach.tech/)
 - [Vuetensils](https://vuetensils.com/)
 - [Angular Material](https://material.angular.io/cdk/a11y/overview)


### PR DESCRIPTION
Thank you for sharing such a helpful a11y introduction guide!

I noticed this typo while reading this blog post. ([text fragment link](https://azukiazusa.dev/blog/web-accessibility-basics-every-web-application-engineer-needs-to-know/#:~:text=Headless%20UI%20%2D%20Unstyled%2C%20fully%20accessible%20UI%20components))