### PR TITLE
Refactor article date display to use Contentful system metadata

### DIFF
--- a/app/src/components/Card/Card.svelte
+++ b/app/src/components/Card/Card.svelte
@@ -11,7 +11,8 @@
     about: string;
     contents: string;
     tags: Pick<Tag, "name" | "slug">[];
-    createdAt: string;
+    publishedDate: string;
+    updatedDate?: string;
     thumbnail: { title: string; url: string };
     slug: string;
     audio?: string;
@@ -22,7 +23,8 @@
     about,
     contents,
     tags,
-    createdAt,
+    publishedDate,
+    updatedDate,
     thumbnail,
     slug,
     audio,
@@ -255,8 +257,27 @@
                 d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
               />
             </svg>
-            <Time date={createdAt} />
+            <span>公開日: </span><Time date={publishedDate} />
           </div>
+          {#if updatedDate && new Date(updatedDate).getTime() !== new Date(publishedDate).getTime()}
+            <div class="flex items-center pr-4" style:--tag="time-updated-{slug}">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                class="mr-1 h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              <span>更新日: </span><Time date={updatedDate} />
+            </div>
+          {/if}
           <div
             class="flex flex-wrap items-center leading-none"
             style:--tag="tag-{slug}"

--- a/app/src/queries/PostBySlug.ts
+++ b/app/src/queries/PostBySlug.ts
@@ -9,18 +9,23 @@ export const postBySlugQuery = gql`
         about
         article
         audio
+        sys {
+          createdAt
+          updatedAt
+        }
         relatedArticleCollection(limit: 5) {
           items {
             title
             slug
-            createdAt
+            sys {
+              createdAt
+            }
             thumbnail {
               title
               url(transform: { format: WEBP, quality: 50 })
             }
           }
         }
-        createdAt
         thumbnail {
           title
           url(transform: { format: WEBP, quality: 50 })

--- a/app/src/routes/blog/[slug]/+page.server.ts
+++ b/app/src/routes/blog/[slug]/+page.server.ts
@@ -19,9 +19,24 @@ export const load: PageServerLoad = async ({ params }) => {
   }
   const input = data.blogPostCollection.items[0].article;
   const contents = await markdownToHtml(input);
+
+  const originalPost = data.blogPostCollection.items[0];
+  const post = {
+    ...originalPost,
+    publishedDate: originalPost.sys.createdAt,
+    updatedDate: originalPost.sys.updatedAt,
+    relatedArticleCollection: {
+      ...originalPost.relatedArticleCollection,
+      items: originalPost.relatedArticleCollection.items.map(item => ({
+        ...item,
+        createdAt: item.sys.createdAt,
+      }))
+    }
+  };
+
   return {
     contents,
-    post: data.blogPostCollection.items[0],
+    post: post,
     contributors,
   };
 };

--- a/app/src/routes/blog/[slug]/+page.svelte
+++ b/app/src/routes/blog/[slug]/+page.svelte
@@ -56,7 +56,8 @@
       title={post.title}
       about={post.about}
       tags={post.tagsCollection.items}
-      createdAt={post.createdAt}
+      publishedDate={post.publishedDate}
+      updatedDate={post.updatedDate}
       audio={post.audio}
       thumbnail={{
         title: post.thumbnail?.title ?? "",


### PR DESCRIPTION
- I modified GraphQL queries to fetch `sys.createdAt` and `sys.updatedAt` for blog posts and `sys.createdAt` for related articles.
- I updated server-side data mapping to process these system dates into `publishedDate` and `updatedDate` fields.
- I modified the `Card` component to:
  - Accept `publishedDate` and `updatedDate` props.
  - Display "公開日:" (Published:) using `publishedDate`.
  - Conditionally display "更新日:" (Updated:) using `updatedDate` only if it differs from `publishedDate`.
- I verified that the `Time` component is compatible with ISO 8601 dates from Contentful.
- I updated the main blog post page to pass the new date props to the `Card` component.

This change ensures that the displayed article creation date is sourced from Contentful's authoritative metadata. It also adds the functionality to display the article's last update date if it differs from the creation date, providing more transparency to you.