### PR TITLE
Fix duplicate quiz choice in ink-cli-app blog post

### DIFF
--- a/contents/blogPost/ink-cli-app.md
+++ b/contents/blogPost/ink-cli-app.md
@@ -20,7 +20,7 @@ selfAssessment:
         - text: "ink-form"
           correct: false
           explanation: null
-        - text: "ink-text-input"
+        - text: "ink-input"
           correct: false
           explanation: null
         - text: "ink-user-input"


### PR DESCRIPTION
## Summary
- Fixed duplicate "ink-text-input" choice in quiz section of ink-cli-app blog post
- Changed one instance to "ink-input" to provide unique quiz options

## Test plan
- [x] Verified the quiz now has unique answer choices
- [x] Confirmed the correct answer remains unchanged
- [x] Checked that the explanation text is preserved

Fixes #1356

🤖 Generated with [Claude Code](https://claude.ai/code)