### PR TITLE
Improve markdown copy button functionality and layout

### DIFF
--- a/app/src/components/Card/Card.svelte
+++ b/app/src/components/Card/Card.svelte
@@ -11,6 +11,7 @@
     title: string;
     about: string;
     contents: string;
+    rawMarkdown: string;
     tags: Pick<Tag, "name" | "slug">[];
     createdAt: string;
     thumbnail: { title: string; url: string };
@@ -18,8 +19,16 @@
     audio?: string;
   }
 
-  let { title, about, contents, tags, createdAt, thumbnail, slug }: Props =
-    $props();
+  let {
+    title,
+    about,
+    contents,
+    rawMarkdown,
+    tags,
+    createdAt,
+    thumbnail,
+    slug,
+  }: Props = $props();
 
   // <baseline-status> を読み込む
   onMount(() => {
@@ -230,6 +239,14 @@
           {slug}
           main
         />
+        <div class="mt-4 flex items-start justify-between gap-4">
+          <h1
+            class="text-3xl font-extrabold leading-tight tracking-tight md:text-4xl lg:text-5xl"
+            style:--tag="h-{slug}"
+          >
+            {title}
+          </h1>
+        </div>
         <div
           class="mt-6 flex flex-wrap items-center gap-2 text-sm font-medium text-gray-600 dark:text-gray-400"
         >
@@ -250,26 +267,17 @@
             </svg>
             <Time date={createdAt} />
           </div>
+        </div>
+        <div class="mt-4 flex flex-wrap items-center justify-between gap-4">
           <div
-            class="flex flex-wrap items-center leading-none"
+            class="flex flex-wrap items-center leading-none self-center"
             style:--tag="tag-{slug}"
           >
             {#each tags as tag (tag.slug)}
               <AppTag {...tag} />
             {/each}
           </div>
-        </div>
-
-        <div class="mt-4 flex items-start justify-between gap-4">
-          <h1
-            class="text-3xl font-extrabold leading-tight tracking-tight md:text-4xl lg:text-5xl"
-            style:--tag="h-{slug}"
-          >
-            {title}
-          </h1>
-          <div class="flex-shrink-0 pt-2">
-            <MarkdownCopyButton {slug} {contents} />
-          </div>
+          <MarkdownCopyButton contents={rawMarkdown} />
         </div>
 
         <p

--- a/app/src/components/Card/Card.svelte
+++ b/app/src/components/Card/Card.svelte
@@ -4,6 +4,7 @@
   import type { Tag } from "../../generated/graphql";
   import Image from "../Image/Image.svelte";
   import NavButton from "./NavButton.svelte";
+  import MarkdownCopyButton from "../MarkdownCopyButton/MarkdownCopyButton.svelte";
   import { onMount } from "svelte";
 
   interface Props {
@@ -259,12 +260,17 @@
           </div>
         </div>
 
-        <h1
-          class="mt-4 text-3xl font-extrabold leading-tight tracking-tight md:text-4xl lg:text-5xl"
-          style:--tag="h-{slug}"
-        >
-          {title}
-        </h1>
+        <div class="mt-4 flex items-start justify-between gap-4">
+          <h1
+            class="text-3xl font-extrabold leading-tight tracking-tight md:text-4xl lg:text-5xl"
+            style:--tag="h-{slug}"
+          >
+            {title}
+          </h1>
+          <div class="flex-shrink-0 pt-2">
+            <MarkdownCopyButton {slug} {contents} />
+          </div>
+        </div>
 
         <p
           class="my-4 text-lg leading-relaxed text-gray-700 dark:text-gray-300"

--- a/app/src/components/MarkdownCopyButton/MarkdownCopyButton.svelte
+++ b/app/src/components/MarkdownCopyButton/MarkdownCopyButton.svelte
@@ -1,28 +1,14 @@
 <script lang="ts">
-  import { onMount } from "svelte";
-
   interface Props {
-    slug: string;
     contents: string;
   }
 
-  let { slug, contents }: Props = $props();
+  let { contents }: Props = $props();
 
-  let showMenu = $state(false);
   let copied = $state(false);
-  let button: HTMLButtonElement;
-
-  function toggleMenu() {
-    showMenu = !showMenu;
-  }
-
-  function closeMenu() {
-    showMenu = false;
-  }
 
   function copyMarkdown() {
     navigator.clipboard.writeText(contents);
-    closeMenu();
 
     // コピー成功のフィードバック
     copied = true;
@@ -30,159 +16,42 @@
       copied = false;
     }, 2000);
   }
-
-  function openMarkdown() {
-    window.open(`/blog/${slug}.md`, "_blank");
-    closeMenu();
-  }
-
-  onMount(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (button && !button.contains(event.target as Node)) {
-        closeMenu();
-      }
-    }
-
-    document.addEventListener("click", handleClickOutside);
-    return () => {
-      document.removeEventListener("click", handleClickOutside);
-    };
-  });
 </script>
 
-<div class="relative inline-block">
-  <div class="flex">
-    <button
-      onclick={copyMarkdown}
-      class="flex items-center gap-2 rounded-l-lg px-4 py-2 text-sm font-medium text-white transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 {copied
-        ? 'bg-green-600 hover:bg-green-700 focus:ring-green-500'
-        : 'bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500'}"
+<button
+  onclick={copyMarkdown}
+  class="inline-flex items-center justify-center rounded-lg px-4 py-2 text-center text-sm transition-all gap-2 bg-transparent text-white border-white/20 dark:border-zinc-700 dark:text-gray-50 border hover:opacity-70"
+>
+  {#if copied}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      class="h-3.5 w-3.5 text-green-500"
     >
-      {#if copied}
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="currentColor"
-          class="h-4 w-4"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M4.5 12.75l6 6 9-13.5"
-          />
-        </svg>
-        コピー完了
-      {:else}
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke-width="1.5"
-          stroke="currentColor"
-          class="h-4 w-4"
-        >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
-          />
-        </svg>
-        マークダウンでコピー
-      {/if}
-    </button>
-    <button
-      bind:this={button}
-      onclick={toggleMenu}
-      aria-label="メニューを開く"
-      class="rounded-r-lg border-l px-2 py-2 text-white transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 {copied
-        ? 'border-green-500 bg-green-600 hover:bg-green-700 focus:ring-green-500'
-        : 'border-indigo-500 bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500'}"
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M4.5 12.75l6 6 9-13.5"
+      />
+    </svg>
+  {:else}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke-width="1.5"
+      stroke="currentColor"
+      class="h-3.5 w-3.5"
     >
-      <svg
-        xmlns="http://www.w3.org/2000/svg"
-        fill="none"
-        viewBox="0 0 24 24"
-        stroke-width="1.5"
-        stroke="currentColor"
-        class="h-4 w-4 transition-transform duration-200 {showMenu
-          ? 'rotate-180'
-          : ''}"
-      >
-        <path
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          d="M19.5 8.25l-7.5 7.5-7.5-7.5"
-        />
-      </svg>
-    </button>
-  </div>
-
-  {#if showMenu}
-    <div
-      class="absolute right-0 top-full z-10 mt-1 w-48 origin-top-right overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 dark:bg-zinc-800 dark:ring-zinc-700"
-    >
-      <div class="py-1">
-        <button
-          onclick={copyMarkdown}
-          class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-zinc-700"
-        >
-          {#if copied}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              stroke="currentColor"
-              class="h-4 w-4 text-green-600"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M4.5 12.75l6 6 9-13.5"
-              />
-            </svg>
-            コピー完了
-          {:else}
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke-width="1.5"
-              stroke="currentColor"
-              class="h-4 w-4"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
-              />
-            </svg>
-            マークダウンをコピー
-          {/if}
-        </button>
-        <button
-          onclick={openMarkdown}
-          class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-zinc-700"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke-width="1.5"
-            stroke="currentColor"
-            class="h-4 w-4"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
-            />
-          </svg>
-          別タブで開く
-        </button>
-      </div>
-    </div>
+      <path
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
+      />
+    </svg>
   {/if}
-</div>
+  Markdown をコピー
+</button>

--- a/app/src/components/MarkdownCopyButton/MarkdownCopyButton.svelte
+++ b/app/src/components/MarkdownCopyButton/MarkdownCopyButton.svelte
@@ -1,0 +1,188 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+
+  interface Props {
+    slug: string;
+    contents: string;
+  }
+
+  let { slug, contents }: Props = $props();
+
+  let showMenu = $state(false);
+  let copied = $state(false);
+  let button: HTMLButtonElement;
+
+  function toggleMenu() {
+    showMenu = !showMenu;
+  }
+
+  function closeMenu() {
+    showMenu = false;
+  }
+
+  function copyMarkdown() {
+    navigator.clipboard.writeText(contents);
+    closeMenu();
+
+    // コピー成功のフィードバック
+    copied = true;
+    setTimeout(() => {
+      copied = false;
+    }, 2000);
+  }
+
+  function openMarkdown() {
+    window.open(`/blog/${slug}.md`, "_blank");
+    closeMenu();
+  }
+
+  onMount(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (button && !button.contains(event.target as Node)) {
+        closeMenu();
+      }
+    }
+
+    document.addEventListener("click", handleClickOutside);
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+    };
+  });
+</script>
+
+<div class="relative inline-block">
+  <div class="flex">
+    <button
+      onclick={copyMarkdown}
+      class="flex items-center gap-2 rounded-l-lg px-4 py-2 text-sm font-medium text-white transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 {copied
+        ? 'bg-green-600 hover:bg-green-700 focus:ring-green-500'
+        : 'bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500'}"
+    >
+      {#if copied}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="h-4 w-4"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M4.5 12.75l6 6 9-13.5"
+          />
+        </svg>
+        コピー完了
+      {:else}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke-width="1.5"
+          stroke="currentColor"
+          class="h-4 w-4"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
+          />
+        </svg>
+        マークダウンでコピー
+      {/if}
+    </button>
+    <button
+      bind:this={button}
+      onclick={toggleMenu}
+      aria-label="メニューを開く"
+      class="rounded-r-lg border-l px-2 py-2 text-white transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 {copied
+        ? 'border-green-500 bg-green-600 hover:bg-green-700 focus:ring-green-500'
+        : 'border-indigo-500 bg-indigo-600 hover:bg-indigo-700 focus:ring-indigo-500'}"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke-width="1.5"
+        stroke="currentColor"
+        class="h-4 w-4 transition-transform duration-200 {showMenu
+          ? 'rotate-180'
+          : ''}"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M19.5 8.25l-7.5 7.5-7.5-7.5"
+        />
+      </svg>
+    </button>
+  </div>
+
+  {#if showMenu}
+    <div
+      class="absolute right-0 top-full z-10 mt-1 w-48 origin-top-right overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 dark:bg-zinc-800 dark:ring-zinc-700"
+    >
+      <div class="py-1">
+        <button
+          onclick={copyMarkdown}
+          class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-zinc-700"
+        >
+          {#if copied}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="h-4 w-4 text-green-600"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M4.5 12.75l6 6 9-13.5"
+              />
+            </svg>
+            コピー完了
+          {:else}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke-width="1.5"
+              stroke="currentColor"
+              class="h-4 w-4"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
+              />
+            </svg>
+            マークダウンをコピー
+          {/if}
+        </button>
+        <button
+          onclick={openMarkdown}
+          class="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 transition-colors hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-zinc-700"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke-width="1.5"
+            stroke="currentColor"
+            class="h-4 w-4"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+            />
+          </svg>
+          別タブで開く
+        </button>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/app/src/components/Tag/Tag.svelte
+++ b/app/src/components/Tag/Tag.svelte
@@ -57,7 +57,7 @@
   <!-- 記事内の小さなタグ -->
   <a
     href={`/tags/${slug}`}
-    class="inline-flex items-center rounded-full bg-gray-100 dark:bg-zinc-800 hover:bg-gray-200 dark:hover:bg-zinc-700 px-3 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 transition-colors mb-2 mr-2"
+    class="inline-flex items-center rounded-full bg-gray-100 dark:bg-zinc-800 hover:bg-gray-200 dark:hover:bg-zinc-700 px-3 py-1 text-xs font-medium text-gray-700 dark:text-gray-300 transition-colors"
   >
     #{name}
     {@render children?.()}

--- a/app/src/routes/blog/[slug]/+page.server.ts
+++ b/app/src/routes/blog/[slug]/+page.server.ts
@@ -21,6 +21,7 @@ export const load: PageServerLoad = async ({ params }) => {
   const contents = await markdownToHtml(input);
   return {
     contents,
+    rawMarkdown: input,
     post: data.blogPostCollection.items[0],
     contributors,
   };

--- a/app/src/routes/blog/[slug]/+page.svelte
+++ b/app/src/routes/blog/[slug]/+page.svelte
@@ -20,6 +20,7 @@
 
   let post = $derived(data.post);
   let contents = $derived(data.contents);
+  let rawMarkdown = $derived(data.rawMarkdown);
   let contributors = $derived(data.contributors);
 
   let url = $derived(`${variables.baseURL}/blog/${post.slug}`);
@@ -63,6 +64,7 @@
         url: post.thumbnail?.url ?? "",
       }}
       {contents}
+      {rawMarkdown}
     />
   {/key}
 


### PR DESCRIPTION
## Summary
- タグとマークダウンコピーボタンを横並びにレイアウト変更
- タグを縦方向に中央配置
- マークダウンコピーボタンがHTMLではなく生のマークダウンをコピーするように修正
- コピー成功時のチェックマークを緑色に変更
- MarkdownCopyButtonコンポーネントを簡素化（ドロップダウンメニューを削除）

## Test plan
- [x] タグとマークダウンコピーボタンが横並びに表示される
- [x] タグが縦方向に中央配置される
- [x] マークダウンコピーボタンをクリックすると生のマークダウンがクリップボードにコピーされる
- [x] コピー成功時にチェックマークが緑色で表示される
- [x] lint と typecheck がパスする

🤖 Generated with [Claude Code](https://claude.ai/code)