### PR TITLE
Improve talks page layout and date visibility

### DIFF
--- a/app/src/components/Time/Time.svelte
+++ b/app/src/components/Time/Time.svelte
@@ -15,7 +15,7 @@
 
 <time
   datetime={date}
-  class="text-grey-darker text-sm text-zinc-900/70 dark:text-gray-50/60"
+  class="text-grey-darker text-base font-medium text-zinc-900/70 dark:text-gray-50/60"
 >
   {format()}
 </time>

--- a/app/src/components/Timeline/Timeline.svelte
+++ b/app/src/components/Timeline/Timeline.svelte
@@ -25,9 +25,7 @@
     class="absolute -left-[14px] top-[12px] flex h-[28px] w-[28px] items-center justify-center rounded-full bg-indigo-700 ring-4 ring-white dark:ring-gray-900"
   >
   </span>
-  <div
-    class="ml-12 bg-white dark:bg-zinc-900 p-6 rounded-lg shadow-lg dark:shadow-none"
-  >
+  <div class="ml-12 bg-white dark:bg-zinc-900 p-6 rounded-lg">
     <h3
       class="mb-1 flex items-center text-xl font-semibold text-gray-900 dark:text-white"
     >

--- a/app/src/routes/talks/+page.svelte
+++ b/app/src/routes/talks/+page.svelte
@@ -10,9 +10,9 @@
   />
 </svelte:head>
 
-<div class="container mx-auto px-4">
+<div class="container mx-auto px-4 max-w-5xl">
   <h1
-    class="mt-16 mb-8 relative text-3xl font-extrabold dark:text-white after:content-[''] after:absolute after:-bottom-3 after:left-0 after:w-20 after:h-1 after:bg-indigo-500"
+    class="my-8 relative text-3xl font-extrabold dark:text-white after:content-[''] after:absolute after:-bottom-3 after:left-0 after:w-20 after:h-1 after:bg-indigo-500"
   >
     登壇資料
   </h1>


### PR DESCRIPTION
## Summary
- Add max-width constraint to talks page for consistent content width across devices
- Increase date font size and weight for better readability
- Clean up Timeline component styling

## Test plan
- [ ] Verify talks page has appropriate max-width on desktop
- [ ] Confirm dates are more visible and readable
- [ ] Check responsive behavior on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)