### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ npm run build
 ### lint & typecheck
 
 ```sh
-$ npn run lint
+$ npm run lint
 $ npm run typecheck
 ```
 

--- a/contents/blogPost/claude-code-hooks-run-formatter.md
+++ b/contents/blogPost/claude-code-hooks-run-formatter.md
@@ -107,7 +107,7 @@ stdin から受け取った JSON データから `tool_input.file_path` を抽�
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path' | select(endswith(\".js\") or endswith(\".ts\") or endswith(\".jsx\") or endswith(\".tsx\")) | xargs -r npx prettier --write"
+            "command": "jq -r '.tool_input.file_path | select(endswith(\".js\") or endswith(\".ts\") or endswith(\".jsx\") or endswith(\".tsx\"))' | xargs -r npx prettier --write"
           }
         ]
       }


### PR DESCRIPTION
https://azukiazusa.dev/blog/claude-code-hooks-run-formatter/ の記事を拝見していたところtypoと思われる記述があったので修正してみました。