### PR TITLE
Cloudflare Workers Tech Talks in Kyoto #1の発表資料を追加

### DIFF
--- a/app/src/components/TalkTimelines.svelte
+++ b/app/src/components/TalkTimelines.svelte
@@ -8,6 +8,15 @@
 
   const slides = [
     {
+      eventTitle: "Cloudflare Workers Tech Talks in Kyoto #1",
+      eventDate: "2025-07-18",
+      presentationTitle: "バイブコーディング超えてバイブデプロイ〜Cloudflare MCP 実現する、未来のアプリケーションデリバリー",
+      presentationLink:
+        "https://speakerdeck.com/azukiazusa1/baibukodeinguchao-etebaibudepuroi-cloudflaremcpdeshi-xian-suru-wei-lai-noapurikesiyonderibari",
+      description:
+        "バイブコーディングとは、AIエージェントが自律的にコードを生成・実行する技術です。Cloudflare Workers MCPを使って、AIエージェントがCloudflareのリソースを操作し、アプリケーションをデプロイする方法を実践します。",
+    },
+    {
       eventTitle: "#さくらのAI Meetup vol.11「Agent2Agent（A2A）」",
       eventDate: "2025-06-25",
       presentationTitle: "A2A プロトコルを試してみる",


### PR DESCRIPTION
## Summary
- Cloudflare Workers Tech Talks in Kyoto #1 (2025-07-18) の発表資料を追加
- 資料タイトル: バイブコーディング超えてバイブデプロイ〜Cloudflare MCP 実現する、未来のアプリケーションデリバリー
- TalkTimelines.svelte の slides 配列に新しいエントリを追加

## Test plan
- [ ] /talks ページで新しい発表資料が表示されることを確認
- [ ] 発表資料のリンクが正しく動作することを確認
- [ ] 年別の表示が正しく行われることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)