### PR TITLE
fix: サイドメニューがヘッダーの上に表示されるようにz-indexを修正

### DIFF
--- a/app/src/components/Header/SideMenu.svelte
+++ b/app/src/components/Header/SideMenu.svelte
@@ -43,7 +43,7 @@
   ></div>
 {/if}
 <aside
-  class={`fixed top-0 left-0 z-50 flex h-full w-72 transform flex-col justify-between overflow-auto bg-white transition-all duration-300 ease-in-out shadow-xl dark:bg-zinc-800 ${
+  class={`fixed top-0 left-0 z-60 flex h-full w-72 transform flex-col justify-between overflow-auto bg-white transition-all duration-300 ease-in-out shadow-xl dark:bg-zinc-800 ${
     isOpen ? "visible translate-x-0 " : "invisible -translate-x-full"
   }`}
 >


### PR DESCRIPTION
## Summary
- サイドメニューのz-indexをz-50からz-60に変更
- これによりサイドメニューがヘッダー(z-50)よりも上のレイヤーに表示される

## Changes
- `app/src/components/Header/SideMenu.svelte`: z-indexをz-50からz-60に変更

## Test plan
- [ ] サイドメニューを開いてヘッダーの上に正しく表示されることを確認
- [ ] モバイルビューでサイドメニューが正常に動作することを確認
- [ ] ダークモードでも正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)