### PR TITLE
fix: リンクカード内の画像を拡大表示の対象外にする

### DIFF
--- a/app/src/components/Card/Card.svelte
+++ b/app/src/components/Card/Card.svelte
@@ -123,8 +123,9 @@
   onMount(() => {
     // 画像をクリックした時、拡大表示する
     const images = document.querySelectorAll("#contents img");
+    // リンク内の画像（リンクカードのサムネイルやファビコンなど）は拡大表示の対象外にする
     const filteredImages = Array.from(images).filter(
-      (image) => !(image.parentElement.tagName === "A"),
+      (image) => !image.closest("a"),
     );
     const handleClick = (e: MouseEvent) => {
       const modal = document.createElement("dialog");


### PR DESCRIPTION
画像クリックで拡大表示する機能で、直接の親要素が <a> かどうかのみ
判定していたため、<a class="link-card"> の深い階層に入れ子になっている
リンクカードのサムネイル・ファビコン画像が除外されていなかった。
closest("a") を用いてリンク内のすべての画像を除外するよう修正。

https://claude.ai/code/session_01PHPtscnkiyn5iAy4P9ipdM