### PR TITLE
Fix link card conversion inside lists

### DIFF
--- a/packages/remark-link-card/src/index.spec.ts
+++ b/packages/remark-link-card/src/index.spec.ts
@@ -94,13 +94,13 @@ describe("remark-link-card", () => {
     const { value } = await processor.process(`
 intro
 
-- [https://github.com/ghuntley/how-to-ralph-wiggum](https://github.com/ghuntley/how-to-ralph-wiggum)
-- [https://ghuntley.com/ralph/](https://ghuntley.com/ralph/)
+- [https://example.com/first-link](https://example.com/first-link)
+- [https://example.org/second-link](https://example.org/second-link)
 `);
     expect(value.toString()).toBe(`<p>intro</p>
 <ul>
-<li><a href="https://github.com/ghuntley/how-to-ralph-wiggum">https://github.com/ghuntley/how-to-ralph-wiggum</a></li>
-<li><a href="https://ghuntley.com/ralph/">https://ghuntley.com/ralph/</a></li>
+<li><a href="https://example.com/first-link">https://example.com/first-link</a></li>
+<li><a href="https://example.org/second-link">https://example.org/second-link</a></li>
 </ul>
 `);
   });

--- a/packages/remark-link-card/src/index.spec.ts
+++ b/packages/remark-link-card/src/index.spec.ts
@@ -90,6 +90,21 @@ describe("remark-link-card", () => {
 `);
   });
 
+  test("リスト内のリンクはカードに変換しない", async () => {
+    const { value } = await processor.process(`
+intro
+
+- [https://github.com/ghuntley/how-to-ralph-wiggum](https://github.com/ghuntley/how-to-ralph-wiggum)
+- [https://ghuntley.com/ralph/](https://ghuntley.com/ralph/)
+`);
+    expect(value.toString()).toBe(`<p>intro</p>
+<ul>
+<li><a href="https://github.com/ghuntley/how-to-ralph-wiggum">https://github.com/ghuntley/how-to-ralph-wiggum</a></li>
+<li><a href="https://ghuntley.com/ralph/">https://ghuntley.com/ralph/</a></li>
+</ul>
+`);
+  });
+
   test("リンクのテキストと URL が異なる場合、カードに変換しない", async () => {
     const { value } = await processor.process(`
 ## test

--- a/packages/remark-link-card/src/index.ts
+++ b/packages/remark-link-card/src/index.ts
@@ -44,7 +44,11 @@ const text = (value = "") => {
 const remarkLinkCard: Plugin = () => async (tree) => {
   const transformers: Promise<void>[] = [];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  visit(tree, "paragraph", (paragraphNode: any, index) => {
+  visit(tree, "paragraph", (paragraphNode: any, index, parent) => {
+    if (parent !== tree) {
+      return;
+    }
+
     if (paragraphNode.children.length !== 1) {
       return;
     }


### PR DESCRIPTION
## Summary
- Limit remark-link-card conversion to root-level paragraphs
- Add a regression test for links inside list items

## Tests
- npm run test -w=remark-link-card
- npm run typecheck -w=remark-link-card