### PR TITLE
Fix favicon injection into link cards

### DIFF
--- a/packages/rehype-link-favicon/src/index.spec.ts
+++ b/packages/rehype-link-favicon/src/index.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { Root } from "hast";
 import { unified } from "unified";
 import markdown from "remark-parse";
 import remark2rehype from "remark-rehype";
@@ -32,6 +33,33 @@ describe("rehypeLinkFavicon", () => {
   ])("%sには favicon を追加しない", async (_, input) => {
     const result = await process(input);
 
+    expect(result).not.toContain("link-favicon");
+  });
+
+  it("文字列の className を持つリンクカードには favicon を追加しない", async () => {
+    const tree = {
+      type: "root",
+      children: [
+        {
+          type: "element",
+          tagName: "a",
+          properties: {
+            className: "link-card",
+            href: "https://example.com/",
+          },
+          children: [{ type: "text", value: "Example" }],
+        },
+      ],
+    };
+
+    const transformedTree = (await unified()
+      .use(rehypeLinkFavicon)
+      .run(tree)) as Root;
+    const result = unified().use(html).stringify(transformedTree);
+
+    expect(result).toBe(
+      '<a class="link-card" href="https://example.com/">Example</a>',
+    );
     expect(result).not.toContain("link-favicon");
   });
 });

--- a/packages/rehype-link-favicon/src/index.ts
+++ b/packages/rehype-link-favicon/src/index.ts
@@ -9,11 +9,24 @@ type HastNode = {
   children?: HastNode[];
 };
 
-const hasClassName = (node: HastNode, className: string) => {
+const getClassNames = (node: HastNode) => {
   const classNames = node.properties?.["className"];
 
-  return Array.isArray(classNames) && classNames.includes(className);
+  if (typeof classNames === "string") {
+    return classNames.split(/\s+/).filter(Boolean);
+  }
+
+  if (Array.isArray(classNames)) {
+    return classNames.filter(
+      (candidate): candidate is string => typeof candidate === "string",
+    );
+  }
+
+  return [];
 };
+
+const hasClassName = (node: HastNode, className: string) =>
+  getClassNames(node).includes(className);
 
 const addFavicon = (node: HastNode) => {
   if (node.type === "element" && node.tagName === "a") {
@@ -38,9 +51,7 @@ const addFavicon = (node: HastNode) => {
       return;
     }
 
-    const classNames = Array.isArray(node.properties?.["className"])
-      ? node.properties["className"]
-      : [];
+    const classNames = getClassNames(node);
     node.properties = {
       ...node.properties,
       className: [...classNames, "link-with-favicon"],


### PR DESCRIPTION
## Summary
- support both string and array className values in the favicon plugin
- exclude generated link cards from favicon injection
- add a regression test for string className link cards

## Verification
- npm test -w=rehype-link-favicon
- npm run typecheck -w=rehype-link-favicon
- npm run lint -w=rehype-link-favicon
- npm run build -w=rehype-link-favicon

## Notes
- Full repository typecheck could not run because Turbo failed to initialize TLS and the local workerd optional binary is missing.