### PR TITLE
feat: 記事の画像・動画を Contentful へ一括アップロードする upload:media を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
     "new:article": "npm run new -w=packages/content-management",
+    "upload:media": "npm run upload:media -w=packages/content-management --",
     "test": "turbo run test",
     "generate:ogp": "npm run generate -w=packages/ogp-generator --"
   },

--- a/packages/content-management/package.json
+++ b/packages/content-management/package.json
@@ -16,6 +16,7 @@
     "sync": "tsx src/commands/sync.ts",
     "update": "tsx src/commands/update.ts",
     "new": "tsx src/commands/new.ts",
+    "upload:media": "tsx src/commands/upload-media.ts",
     "validate": "tsx src/commands/validate.ts",
     "recap": "tsx src/commands/recap.ts"
   },

--- a/packages/content-management/src/api.ts
+++ b/packages/content-management/src/api.ts
@@ -1,3 +1,4 @@
+import { createReadStream } from "node:fs";
 import contentful, { MetaLinkProps } from "contentful-management";
 import { BetaAnalyticsDataClient } from "@google-analytics/data";
 import slugify from "slugify";
@@ -603,4 +604,59 @@ export const getPopularPosts = async ({
     };
   });
   return popularPosts;
+};
+
+export type UploadedAsset = {
+  url: string;
+  assetId: string;
+};
+
+/**
+ * ローカルのファイルを Contentful の Asset として登録し、公開して URL を返す。
+ *
+ * Asset は publish しないと URL が 403 を返すため、必ず publish まで行う。
+ */
+export const uploadAsset = async ({
+  filePath,
+  fileName,
+  contentType,
+  title,
+}: {
+  filePath: string;
+  fileName: string;
+  contentType: string;
+  title: string;
+}): Promise<UploadedAsset> => {
+  const client = await createClient();
+
+  const asset = await client.createAssetFromFiles({
+    fields: {
+      title: { "en-US": title },
+      description: { "en-US": "" },
+      file: {
+        "en-US": {
+          contentType,
+          fileName,
+          file: createReadStream(filePath),
+        },
+      },
+    },
+  });
+
+  // 画像処理は非同期。既定の 500ms x 5 回では動画に足りないので待ち時間を伸ばす
+  const processed = await asset.processForAllLocales({
+    processingCheckWait: 2000,
+    processingCheckRetries: 30,
+  });
+
+  const published = await processed.publish();
+
+  const url = published.fields.file["en-US"]?.url;
+
+  if (!url) {
+    throw new Error(`Asset の URL を取得できませんでした: ${fileName}`);
+  }
+
+  // Contentful は "//images.ctfassets.net/..." のようなプロトコル相対 URL を返す
+  return { url: `https:${url}`, assetId: published.sys.id };
 };

--- a/packages/content-management/src/commands/upload-media.ts
+++ b/packages/content-management/src/commands/upload-media.ts
@@ -1,0 +1,25 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { uploadMedia } from "../uploadMedia.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const [id, ...options] = process.argv.slice(2);
+
+if (!id) {
+  console.error(
+    "記事 ID を指定してください: npm run upload:media -w=packages/content-management -- <記事 ID> [--dry-run]",
+  );
+  process.exit(1);
+}
+
+try {
+  await uploadMedia({
+    blogPostDir: join(__dirname, "../../../../contents/blogPost"),
+    id,
+    dryRun: options.includes("--dry-run"),
+  });
+} catch (error) {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+}

--- a/packages/content-management/src/image.ts
+++ b/packages/content-management/src/image.ts
@@ -1,0 +1,28 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+
+/**
+ * Web で扱えない画像形式を PNG へ変換する。
+ *
+ * macOS のクリップボードは public.tiff が標準の画像型なので、
+ * Zed に貼り付けた画像が .tiff で書き出されることがある。
+ * TIFF は無圧縮のため、同じ絵でも PNG の 20 倍以上のサイズになる。
+ * TIFF から PNG への変換は可逆で、アルファチャンネルも保たれる。
+ */
+export const convertImageToPng = async (
+  input: string,
+  output: string,
+): Promise<void> => {
+  await run("ffmpeg", [
+    "-y",
+    "-i",
+    input,
+    "-frames:v",
+    "1",
+    "-update",
+    "1",
+    output,
+  ]);
+};

--- a/packages/content-management/src/media.spec.ts
+++ b/packages/content-management/src/media.spec.ts
@@ -1,0 +1,233 @@
+import { describe, test, expect } from "vitest";
+import {
+  findLocalMedia,
+  nextSequence,
+  assetFileName,
+  replaceReference,
+  contentTypeOf,
+  needsImageConversion,
+  isSupported,
+} from "./media.ts";
+
+const imageRef = (filePath: string) => ({
+  kind: "image" as const,
+  raw: "",
+  filePath,
+  alt: "",
+});
+
+const videoRef = (filePath: string) => ({
+  kind: "video" as const,
+  raw: "",
+  filePath,
+  alt: "",
+});
+
+describe("findLocalMedia", () => {
+  test("ローカルの画像参照を alt ごと取り出す", () => {
+    const references = findLocalMedia("![説明](image_1.png)");
+    expect(references).toEqual([
+      {
+        kind: "image",
+        raw: "![説明](image_1.png)",
+        filePath: "image_1.png",
+        alt: "説明",
+      },
+    ]);
+  });
+
+  test("alt が空でも取り出す", () => {
+    expect(findLocalMedia("![](image.png)")[0]?.alt).toBe("");
+  });
+
+  test("アップロード済みの URL は無視する", () => {
+    expect(
+      findLocalMedia(
+        "![](https://images.ctfassets.net/a/b/c/d.png)\n![](//images.ctfassets.net/a/b/c/e.png)",
+      ),
+    ).toEqual([]);
+  });
+
+  test("ローカルの動画参照を取り出す", () => {
+    const references = findLocalMedia("!v(recording.mov)");
+    expect(references[0]).toMatchObject({
+      kind: "video",
+      raw: "!v(recording.mov)",
+      filePath: "recording.mov",
+    });
+  });
+
+  test("寸法付きのアップロード済み動画は無視する", () => {
+    expect(
+      findLocalMedia(
+        "!v(https://downloads.ctfassets.net/a/b/c/d.mp4 1280x720)",
+      ),
+    ).toEqual([]);
+  });
+
+  test("画像と動画が混在していても両方取り出す", () => {
+    const references = findLocalMedia("![](a.png)\n\n!v(b.mov)");
+    expect(references.map((r) => r.kind)).toEqual(["image", "video"]);
+  });
+
+  test("通常のリンクは画像として拾わない", () => {
+    expect(findLocalMedia("[リンク](./page.md)")).toEqual([]);
+  });
+});
+
+describe("nextSequence", () => {
+  test("使われていなければ 1 から始める", () => {
+    expect(nextSequence(["![](image.png)"], "example-slug")).toBe(1);
+  });
+
+  test("既存の最大値の次を返す", () => {
+    const ja = "![](https://images.ctfassets.net/a/b/c/example-slug-1.png)";
+    const en = "![](https://images.ctfassets.net/a/b/c/example-slug-3.png)";
+    expect(nextSequence([ja, en], "example-slug")).toBe(4);
+  });
+
+  test("動画の連番も同じ空間で数える", () => {
+    const article =
+      "!v(https://downloads.ctfassets.net/a/b/c/s-2.mp4 1280x720)";
+    expect(nextSequence([article], "s")).toBe(3);
+  });
+});
+
+describe("assetFileName", () => {
+  test("画像は元の拡張子を保つ", () => {
+    expect(
+      assetFileName("example-slug", 2, {
+        kind: "image",
+        raw: "",
+        filePath: "image_1.PNG",
+        alt: "",
+      }),
+    ).toBe("example-slug-2.png");
+  });
+
+  test("tiff は png になる", () => {
+    expect(assetFileName("example-slug", 1, imageRef("image.tiff"))).toBe(
+      "example-slug-1.png",
+    );
+  });
+
+  test("動画は常に mp4 になる", () => {
+    expect(
+      assetFileName("example-slug", 1, {
+        kind: "video",
+        raw: "",
+        filePath: "recording.mov",
+        alt: "",
+      }),
+    ).toBe("example-slug-1.mp4");
+  });
+});
+
+describe("needsImageConversion", () => {
+  test("macOS のクリップボード由来の tiff は変換する", () => {
+    expect(needsImageConversion(imageRef("image.tiff"))).toBe(true);
+    expect(needsImageConversion(imageRef("image.TIF"))).toBe(true);
+  });
+
+  test("そのまま上げられる形式は変換しない", () => {
+    expect(needsImageConversion(imageRef("image.png"))).toBe(false);
+    expect(needsImageConversion(imageRef("image.gif"))).toBe(false);
+  });
+});
+
+describe("isSupported", () => {
+  test("画像は変換ありなしのどちらも通す", () => {
+    expect(isSupported(imageRef("a.png"))).toBe(true);
+    expect(isSupported(imageRef("a.webp"))).toBe(true);
+    expect(isSupported(imageRef("a.tiff"))).toBe(true);
+  });
+
+  test("動画は mov と mp4 だけ通す", () => {
+    expect(isSupported(videoRef("a.mov"))).toBe(true);
+    expect(isSupported(videoRef("a.mp4"))).toBe(true);
+    expect(isSupported(videoRef("a.avi"))).toBe(false);
+  });
+
+  test("対応していない形式は弾く", () => {
+    expect(isSupported(imageRef("a.svg"))).toBe(false);
+    expect(isSupported(imageRef("a.pdf"))).toBe(false);
+  });
+});
+
+describe("replaceReference", () => {
+  const url = "https://images.ctfassets.net/a/b/c/example-slug-1.png";
+
+  test("画像は alt を保ったまま URL に置き換える", () => {
+    const reference = {
+      kind: "image" as const,
+      raw: "![説明](image_1.png)",
+      filePath: "image_1.png",
+      alt: "説明",
+    };
+    expect(
+      replaceReference("前\n![説明](image_1.png)\n後", reference, url),
+    ).toBe(`前\n![説明](${url})\n後`);
+  });
+
+  test("同じ参照が複数あればすべて置き換える", () => {
+    const reference = {
+      kind: "image" as const,
+      raw: "![](a.png)",
+      filePath: "a.png",
+      alt: "",
+    };
+    expect(replaceReference("![](a.png) と ![](a.png)", reference, url)).toBe(
+      `![](${url}) と ![](${url})`,
+    );
+  });
+
+  test("alt が違っても同じファイルなら置き換える", () => {
+    const reference = {
+      kind: "image" as const,
+      raw: "![図](image.png)",
+      filePath: "image.png",
+      alt: "図",
+    };
+    expect(replaceReference("![Diagram](image.png)", reference, url)).toBe(
+      `![Diagram](${url})`,
+    );
+  });
+
+  test("別のファイルは置き換えない", () => {
+    const reference = {
+      kind: "image" as const,
+      raw: "![](a.png)",
+      filePath: "a.png",
+      alt: "",
+    };
+    expect(replaceReference("![](b.png)", reference, url)).toBe("![](b.png)");
+  });
+
+  test("動画は寸法付きで置き換える", () => {
+    const reference = {
+      kind: "video" as const,
+      raw: "!v(recording.mov)",
+      filePath: "recording.mov",
+      alt: "",
+    };
+    const videoUrl = "https://downloads.ctfassets.net/a/b/c/example-slug-1.mp4";
+    expect(
+      replaceReference("!v(recording.mov)", reference, videoUrl, {
+        width: 1280,
+        height: 720,
+      }),
+    ).toBe(`!v(${videoUrl} 1280x720)`);
+  });
+});
+
+describe("contentTypeOf", () => {
+  test("拡張子から Content-Type を返す", () => {
+    expect(contentTypeOf("a.png")).toBe("image/png");
+    expect(contentTypeOf("a.JPG")).toBe("image/jpeg");
+    expect(contentTypeOf("a.mp4")).toBe("video/mp4");
+  });
+
+  test("対応していない拡張子は例外にする", () => {
+    expect(() => contentTypeOf("a.mov")).toThrowError();
+  });
+});

--- a/packages/content-management/src/media.ts
+++ b/packages/content-management/src/media.ts
@@ -1,0 +1,170 @@
+import path from "path";
+
+export type MediaKind = "image" | "video";
+
+export type MediaReference = {
+  kind: MediaKind;
+  /** マッチした記法全体。置換時にそのまま差し替える */
+  raw: string;
+  /** 参照先のローカルパス */
+  filePath: string;
+  /** `![alt](...)` の alt。動画は空文字 */
+  alt: string;
+};
+
+/** `![alt](path)`。パスに空白は許さない（Zed が生成する名前は空白を含まない） */
+const IMAGE_PATTERN = /!\[([^\]]*)\]\(\s*([^)\s]+)\s*\)/g;
+
+/** `!v(path)` または `!v(path 1280x720)` */
+const VIDEO_PATTERN = /!v\(\s*([^)\s]+)(?:\s+\d+x\d+)?\s*\)/g;
+
+/** 既存記事は `//images.ctfassets.net/...` のプロトコル相対 URL も使っている */
+const isRemote = (url: string) => /^(?:https?:)?\/\//.test(url);
+
+/** そのまま Contentful へ上げられる画像形式 */
+const PASSTHROUGH_IMAGE_EXTENSIONS = [".png", ".jpg", ".jpeg", ".gif", ".webp"];
+
+/**
+ * PNG へ変換してから上げる画像形式。
+ *
+ * macOS のクリップボードは public.tiff が標準の画像型なので、
+ * Zed の貼り付けが .tiff になることがある。
+ */
+const CONVERTED_IMAGE_EXTENSIONS = [".tiff", ".tif", ".bmp", ".heic", ".heif"];
+
+const VIDEO_EXTENSIONS = [".mov", ".mp4"];
+
+const extensionOf = (filePath: string) => path.extname(filePath).toLowerCase();
+
+/** TIFF などは PNG に変換してからアップロードする */
+export const needsImageConversion = (reference: MediaReference): boolean =>
+  reference.kind === "image" &&
+  CONVERTED_IMAGE_EXTENSIONS.includes(extensionOf(reference.filePath));
+
+/** アップロードできる形式かどうか。1 件も上げる前に確かめる */
+export const isSupported = (reference: MediaReference): boolean => {
+  const extension = extensionOf(reference.filePath);
+
+  return reference.kind === "video"
+    ? VIDEO_EXTENSIONS.includes(extension)
+    : PASSTHROUGH_IMAGE_EXTENSIONS.includes(extension) ||
+        CONVERTED_IMAGE_EXTENSIONS.includes(extension);
+};
+
+const CONTENT_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".mp4": "video/mp4",
+};
+
+export const contentTypeOf = (fileName: string): string => {
+  const contentType = CONTENT_TYPES[path.extname(fileName).toLowerCase()];
+
+  if (!contentType) {
+    throw new Error(`対応していない拡張子です: ${fileName}`);
+  }
+
+  return contentType;
+};
+
+/**
+ * 本文からアップロードされていないローカルの画像・動画参照を、出現順に取り出す。
+ */
+export const findLocalMedia = (article: string): MediaReference[] => {
+  const references: MediaReference[] = [];
+
+  for (const match of article.matchAll(IMAGE_PATTERN)) {
+    const [raw, alt, filePath] = match;
+
+    if (filePath && !isRemote(filePath)) {
+      references.push({ kind: "image", raw, filePath, alt: alt ?? "" });
+    }
+  }
+
+  for (const match of article.matchAll(VIDEO_PATTERN)) {
+    const [raw, filePath] = match;
+
+    if (filePath && !isRemote(filePath)) {
+      references.push({ kind: "video", raw, filePath, alt: "" });
+    }
+  }
+
+  return references;
+};
+
+/**
+ * 記事内で既に使われている連番の次の値を返す。
+ *
+ * 一度アップロードした記事に画像を足して再実行したとき、
+ * 既存の `<slug>-1.png` と衝突しないようにする。
+ */
+export const nextSequence = (articles: string[], slug: string): number => {
+  const pattern = new RegExp(`${slug}-(\\d+)\\.[A-Za-z0-9]+`, "g");
+  let max = 0;
+
+  for (const article of articles) {
+    for (const [, sequence] of article.matchAll(pattern)) {
+      max = Math.max(max, Number(sequence));
+    }
+  }
+
+  return max + 1;
+};
+
+/**
+ * `<slug>-<連番>.<拡張子>` を組み立てる。動画は常に mp4 へ変換する。
+ */
+export const assetFileName = (
+  slug: string,
+  sequence: number,
+  reference: MediaReference,
+): string => {
+  if (reference.kind === "video") {
+    return `${slug}-${sequence}.mp4`;
+  }
+
+  const extension = needsImageConversion(reference)
+    ? ".png"
+    : extensionOf(reference.filePath);
+
+  return `${slug}-${sequence}${extension}`;
+};
+
+/**
+ * 同じファイルを指すローカル参照を、アップロード後の記法へすべて置き換える。
+ *
+ * 日本語と英語で alt が異なることがあるため、マッチした文字列ではなく
+ * 参照先のファイル名で照合し、alt は各出現のものを保つ。
+ *
+ * 動画には寸法を付ける。remark-video が width / height として出力し、
+ * 読み込み前後のレイアウトシフトを防ぐ。
+ */
+export const replaceReference = (
+  article: string,
+  reference: MediaReference,
+  url: string,
+  size?: { width: number; height: number },
+): string => {
+  const fileName = path.basename(reference.filePath);
+  const isSameFile = (filePath: string) =>
+    !isRemote(filePath) && path.basename(filePath) === fileName;
+
+  if (reference.kind === "image") {
+    return article.replace(
+      new RegExp(IMAGE_PATTERN.source, "g"),
+      (raw, alt: string, filePath: string) =>
+        isSameFile(filePath) ? `![${alt}](${url})` : raw,
+    );
+  }
+
+  const dimensions = size ? ` ${size.width}x${size.height}` : "";
+
+  return article.replace(
+    new RegExp(VIDEO_PATTERN.source, "g"),
+    (raw, filePath: string) =>
+      isSameFile(filePath) ? `!v(${url}${dimensions})` : raw,
+  );
+};

--- a/packages/content-management/src/types.spec.ts
+++ b/packages/content-management/src/types.spec.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect } from "vitest";
+import { BlogPostSchema } from "./types.ts";
+
+const basePost = {
+  id: "aU3AJ8y-gPMSvWfAfMh2y",
+  title: "タイトル",
+  slug: "example-slug",
+  about: "概要",
+  createdAt: "2026-09-05T13:33+09:00",
+  updatedAt: "2026-09-05T13:33+09:00",
+  tags: ["React"],
+  thumbnail: {
+    url: "https://images.ctfassets.net/in6v9lxmm5c8/xxx/yyy/thumbnail.png",
+    title: "サムネイル",
+  },
+  published: true as const,
+};
+
+const parse = (article: string, published = true) =>
+  BlogPostSchema.safeParse({ ...basePost, article, published });
+
+const errorMessages = (result: ReturnType<typeof parse>) =>
+  result.success ? [] : result.error.issues.map((i) => i.message);
+
+describe("BlogPostSchema の article", () => {
+  test("アップロード済みの画像 URL は通る", () => {
+    const result = parse(
+      "![説明](https://images.ctfassets.net/in6v9lxmm5c8/xxx/yyy/example-slug-1.png)",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  test("プロトコル相対の画像 URL も通る", () => {
+    const result = parse(
+      "![説明](//images.ctfassets.net/in6v9lxmm5c8/xxx/yyy/example-slug-1.png)",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  test("アップロード済みの動画 URL は通る", () => {
+    const result = parse(
+      "!v(https://downloads.ctfassets.net/in6v9lxmm5c8/xxx/yyy/example-slug-1.mp4 1280x720)",
+    );
+    expect(result.success).toBe(true);
+  });
+
+  test("ローカルの画像パスが残っていると弾く", () => {
+    const result = parse("![](image_1.png)");
+    expect(result.success).toBe(false);
+    expect(errorMessages(result).join()).toContain("image_1.png");
+  });
+
+  test("ローカルの動画パスが残っていると弾く", () => {
+    const result = parse("!v(recording.mov)");
+    expect(result.success).toBe(false);
+    expect(errorMessages(result).join()).toContain("recording.mov");
+  });
+
+  test("プロトコル相対の動画 URL は弾く", () => {
+    // remark-video は new URL() で検証するため、プロトコル相対だと再生できない
+    const result = parse(
+      "!v(//downloads.ctfassets.net/in6v9lxmm5c8/xxx/yyy/example-slug-1.mp4 1280x720)",
+    );
+    expect(result.success).toBe(false);
+  });
+
+  test("複数のローカル参照をまとめて報告する", () => {
+    const result = parse("![](image.png)\n\n!v(recording.mov)");
+    const message = errorMessages(result).join();
+    expect(message).toContain("image.png");
+    expect(message).toContain("recording.mov");
+  });
+
+  test("下書きのうちはローカルパスが残っていても通る", () => {
+    const result = BlogPostSchema.safeParse({
+      ...basePost,
+      article: "![](image_1.png)",
+      published: false,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/content-management/src/types.ts
+++ b/packages/content-management/src/types.ts
@@ -31,11 +31,68 @@ export const isSelfAssessment = (value: unknown): value is SelfAssessment => {
   return selfAssessmentSchema.safeParse(value).success;
 };
 
+/**
+ * 本文中の Markdown 画像 `![alt](url)` と動画 `!v(url)` の参照先を取り出す
+ */
+const IMAGE_REFERENCE = /!\[[^\]]*\]\(\s*([^)\s]+)/g;
+const VIDEO_REFERENCE = /!v\(\s*([^)\s]+)/g;
+
+/** 既存記事は `//images.ctfassets.net/...` のプロトコル相対 URL も使っている */
+const isRemoteImage = (url: string) => /^(?:https?:)?\/\//.test(url);
+
+/** remark-video は new URL() で検証するため、プロトコル相対 URL は再生できない */
+const isRemoteVideo = (url: string) => /^https?:\/\//.test(url);
+
+/**
+ * アップロードされずに残ったローカルの画像・動画参照を集める。
+ *
+ * 執筆中の Markdown には Zed が貼り付けた `![](image_1.png)` や、
+ * 手で置いた `!v(recording.mov)` のようなローカルパスが入る。
+ * 公開時にこれが残ると Contentful 側の本文が壊れるため、
+ * published: true の記事でだけ弾く。
+ */
+const findLocalMediaReferences = (article: string): string[] => {
+  const references: string[] = [];
+
+  for (const [, url] of article.matchAll(IMAGE_REFERENCE)) {
+    if (url && !isRemoteImage(url)) {
+      references.push(url);
+    }
+  }
+
+  for (const [, url] of article.matchAll(VIDEO_REFERENCE)) {
+    if (url && !isRemoteVideo(url)) {
+      references.push(url);
+    }
+  }
+
+  return references;
+};
+
+const publishedArticleSchema = z
+  .string()
+  .max(50000)
+  .superRefine((article, ctx) => {
+    const references = findLocalMediaReferences(article);
+
+    if (references.length === 0) {
+      return;
+    }
+
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "アップロードされていないローカルの画像・動画が残っています: " +
+        references.join(", ") +
+        "。npm run upload:media -w=packages/content-management -- <記事 ID> を実行してください。",
+    });
+  });
+
 export const BlogPostSchema = z.discriminatedUnion("published", [
   z.object({
     id: z.string(),
     about: z.string().max(255),
-    article: z.string().max(50000),
+    article: publishedArticleSchema,
     createdAt: z
       .string()
       .refine((v) => new Date(v).toString() !== "Invalid Date"),

--- a/packages/content-management/src/uploadMedia.spec.ts
+++ b/packages/content-management/src/uploadMedia.spec.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  writeFile,
+  access,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const mocks = vi.hoisted(() => ({
+  uploadAsset: vi.fn(),
+  transcodeVideo: vi.fn(),
+  probeVideoSize: vi.fn(),
+  convertImageToPng: vi.fn(),
+}));
+
+vi.mock("./api.ts", () => ({ uploadAsset: mocks.uploadAsset }));
+vi.mock("./video.ts", () => ({
+  transcodeVideo: mocks.transcodeVideo,
+  probeVideoSize: mocks.probeVideoSize,
+}));
+vi.mock("./image.ts", () => ({ convertImageToPng: mocks.convertImageToPng }));
+
+const { uploadMedia } = await import("./uploadMedia.ts");
+
+const frontMatter = (title: string) => `---
+id: testId
+title: "${title}"
+slug: "example-slug"
+about: "概要"
+createdAt: "2026-09-05T16:00+09:00"
+updatedAt: "2026-09-05T16:00+09:00"
+tags: ["Test"]
+thumbnail:
+  url: "https://images.ctfassets.net/a/b/c/thumb.png"
+  title: "サムネイル"
+audio: null
+published: false
+---
+`;
+
+let blogPostDir: string;
+const logs: string[] = [];
+const log = (message: string) => logs.push(message);
+
+const writeJa = (body: string) =>
+  writeFile(
+    join(blogPostDir, "testId.md"),
+    frontMatter("記事") + body,
+    "utf-8",
+  );
+const writeEn = (body: string) =>
+  writeFile(
+    join(blogPostDir, "en", "testId.md"),
+    frontMatter("Post") + body,
+    "utf-8",
+  );
+const readJa = () => readFile(join(blogPostDir, "testId.md"), "utf-8");
+const readEn = () => readFile(join(blogPostDir, "en", "testId.md"), "utf-8");
+
+const exists = (filePath: string) =>
+  access(filePath).then(
+    () => true,
+    () => false,
+  );
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  logs.length = 0;
+  blogPostDir = await mkdtemp(join(tmpdir(), "upload-media-spec-"));
+  await mkdir(join(blogPostDir, "en"));
+  mocks.uploadAsset.mockImplementation(async ({ fileName }) => ({
+    url: `https://images.ctfassets.net/space/asset/token/${fileName}`,
+    assetId: "assetId",
+  }));
+  mocks.probeVideoSize.mockResolvedValue({ width: 1280, height: 720 });
+  mocks.transcodeVideo.mockImplementation(async (_input, output) => {
+    await writeFile(output, "transcoded", "utf-8");
+  });
+  mocks.convertImageToPng.mockImplementation(async (_input, output) => {
+    await writeFile(output, "converted", "utf-8");
+  });
+});
+
+afterEach(async () => {
+  await rm(blogPostDir, { recursive: true, force: true });
+});
+
+describe("uploadMedia", () => {
+  test("画像をアップロードして URL に置き換え、ローカルファイルを消す", async () => {
+    await writeJa("![説明](image.png)");
+    await writeFile(join(blogPostDir, "image.png"), "png", "utf-8");
+
+    await uploadMedia({ blogPostDir, id: "testId", log });
+
+    expect(await readJa()).toContain(
+      "![説明](https://images.ctfassets.net/space/asset/token/example-slug-1.png)",
+    );
+    expect(await exists(join(blogPostDir, "image.png"))).toBe(false);
+  });
+
+  test("日英から参照された同じ画像は 1 度だけアップロードして両方置き換える", async () => {
+    await writeJa("![図](image.png)\n\nもう一度 ![図](image.png)");
+    await writeEn("![Diagram](image.png)");
+    await writeFile(join(blogPostDir, "image.png"), "png", "utf-8");
+
+    await uploadMedia({ blogPostDir, id: "testId", log });
+
+    expect(mocks.uploadAsset).toHaveBeenCalledTimes(1);
+
+    const url =
+      "https://images.ctfassets.net/space/asset/token/example-slug-1.png";
+    expect((await readJa()).match(new RegExp(url, "g"))).toHaveLength(2);
+    expect(await readEn()).toContain(`![Diagram](${url})`);
+  });
+
+  test("動画は mp4 に変換し、寸法付きの記法に置き換える", async () => {
+    await writeJa("!v(recording.mov)");
+    await writeFile(join(blogPostDir, "recording.mov"), "mov", "utf-8");
+
+    await uploadMedia({ blogPostDir, id: "testId", log });
+
+    expect(mocks.transcodeVideo).toHaveBeenCalledTimes(1);
+    expect(await readJa()).toContain(
+      "!v(https://images.ctfassets.net/space/asset/token/example-slug-1.mp4 1280x720)",
+    );
+    expect(await exists(join(blogPostDir, "recording.mov"))).toBe(false);
+  });
+
+  test("tiff は png に変換してからアップロードする", async () => {
+    await writeJa("![図](image.tiff)");
+    await writeFile(join(blogPostDir, "image.tiff"), "tiff", "utf-8");
+
+    await uploadMedia({ blogPostDir, id: "testId", log });
+
+    expect(mocks.convertImageToPng).toHaveBeenCalledTimes(1);
+    expect(mocks.uploadAsset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        fileName: "example-slug-1.png",
+        contentType: "image/png",
+      }),
+    );
+    expect(await readJa()).toContain(
+      "![図](https://images.ctfassets.net/space/asset/token/example-slug-1.png)",
+    );
+    expect(await exists(join(blogPostDir, "image.tiff"))).toBe(false);
+  });
+
+  test("対応していない形式があれば 1 件もアップロードしない", async () => {
+    await writeJa("![](image.png)\n\n![](diagram.svg)");
+    await writeFile(join(blogPostDir, "image.png"), "png", "utf-8");
+    await writeFile(join(blogPostDir, "diagram.svg"), "svg", "utf-8");
+
+    await expect(
+      uploadMedia({ blogPostDir, id: "testId", log }),
+    ).rejects.toThrow("対応していない形式");
+
+    expect(mocks.uploadAsset).not.toHaveBeenCalled();
+  });
+
+  test("既に使われている連番の次から振る", async () => {
+    await writeJa(
+      "![](https://images.ctfassets.net/a/b/c/example-slug-3.png)\n\n![](image.png)",
+    );
+    await writeFile(join(blogPostDir, "image.png"), "png", "utf-8");
+
+    await uploadMedia({ blogPostDir, id: "testId", log });
+
+    expect(mocks.uploadAsset).toHaveBeenCalledWith(
+      expect.objectContaining({ fileName: "example-slug-4.png" }),
+    );
+  });
+
+  test("アップロード済みだけの記事では何もしない", async () => {
+    await writeJa("![](https://images.ctfassets.net/a/b/c/example-slug-1.png)");
+
+    await uploadMedia({ blogPostDir, id: "testId", log });
+
+    expect(mocks.uploadAsset).not.toHaveBeenCalled();
+  });
+
+  test("参照先が無いときは 1 件もアップロードせずに失敗する", async () => {
+    await writeJa("![](image.png)\n\n![](missing.png)");
+    await writeFile(join(blogPostDir, "image.png"), "png", "utf-8");
+
+    await expect(
+      uploadMedia({ blogPostDir, id: "testId", log }),
+    ).rejects.toThrow("missing.png");
+
+    expect(mocks.uploadAsset).not.toHaveBeenCalled();
+    expect(await exists(join(blogPostDir, "image.png"))).toBe(true);
+  });
+
+  test("dry-run ではアップロードも削除も書き換えもしない", async () => {
+    await writeJa("![](image.png)");
+    await writeFile(join(blogPostDir, "image.png"), "png", "utf-8");
+
+    await uploadMedia({ blogPostDir, id: "testId", dryRun: true, log });
+
+    expect(mocks.uploadAsset).not.toHaveBeenCalled();
+    expect(await readJa()).toContain("![](image.png)");
+    expect(await exists(join(blogPostDir, "image.png"))).toBe(true);
+    expect(logs.join("\n")).toContain("example-slug-1.png");
+  });
+
+  test("記事が無ければ失敗する", async () => {
+    await expect(
+      uploadMedia({ blogPostDir, id: "unknown", log }),
+    ).rejects.toThrow("記事が見つかりません");
+  });
+
+  test("英語側だけに残ったローカル参照も処理する", async () => {
+    await writeJa("![](https://images.ctfassets.net/a/b/c/example-slug-1.png)");
+    await writeEn("![Diagram](later.png)");
+    await writeFile(join(blogPostDir, "en", "later.png"), "png", "utf-8");
+
+    await uploadMedia({ blogPostDir, id: "testId", log });
+
+    expect(await readEn()).toContain(
+      "![Diagram](https://images.ctfassets.net/space/asset/token/example-slug-2.png)",
+    );
+    expect(await exists(join(blogPostDir, "en", "later.png"))).toBe(false);
+  });
+});

--- a/packages/content-management/src/uploadMedia.ts
+++ b/packages/content-management/src/uploadMedia.ts
@@ -1,0 +1,212 @@
+import {
+  access,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import yamlFront from "yaml-front-matter";
+import { uploadAsset } from "./api.ts";
+import { convertImageToPng } from "./image.ts";
+import {
+  assetFileName,
+  contentTypeOf,
+  findLocalMedia,
+  isSupported,
+  needsImageConversion,
+  nextSequence,
+  replaceReference,
+  type MediaReference,
+} from "./media.ts";
+import { probeVideoSize, transcodeVideo, type VideoSize } from "./video.ts";
+
+const exists = (filePath: string) =>
+  access(filePath).then(
+    () => true,
+    () => false,
+  );
+
+const formatSize = (bytes: number) => `${(bytes / 1024).toFixed(1)} KB`;
+
+type Target = { label: string; filePath: string; content: string };
+
+/**
+ * 同じファイルが日英の両方から参照されることがあるため basename で束ね、
+ * 1 度だけアップロードする。参照先は md のあるディレクトリを基準に解決するので、
+ * Zed が挿入するパスの形式に依存しない。
+ */
+type Job = { reference: MediaReference; sourcePath: string };
+
+export const uploadMedia = async ({
+  blogPostDir,
+  id,
+  dryRun = false,
+  log = console.log,
+}: {
+  blogPostDir: string;
+  id: string;
+  dryRun?: boolean;
+  log?: (message: string) => void;
+}): Promise<void> => {
+  const targets: Target[] = [];
+
+  for (const [label, filePath] of [
+    ["ja", join(blogPostDir, `${id}.md`)],
+    ["en", join(blogPostDir, "en", `${id}.md`)],
+  ] as const) {
+    if (await exists(filePath)) {
+      targets.push({
+        label,
+        filePath,
+        content: await readFile(filePath, "utf-8"),
+      });
+    }
+  }
+
+  if (targets.length === 0) {
+    throw new Error(`記事が見つかりません: ${id}`);
+  }
+
+  const slug = yamlFront.loadFront(targets[0]!.content)["slug"];
+
+  if (typeof slug !== "string" || !slug) {
+    throw new Error(
+      `frontmatter に slug がありません: ${targets[0]!.filePath}`,
+    );
+  }
+
+  const jobs = new Map<string, Job>();
+  const missing: string[] = [];
+  const unsupported: string[] = [];
+
+  for (const target of targets) {
+    for (const reference of findLocalMedia(target.content)) {
+      const fileName = basename(reference.filePath);
+
+      if (jobs.has(fileName)) {
+        continue;
+      }
+
+      if (!isSupported(reference)) {
+        unsupported.push(`${reference.raw} (${target.label})`);
+        continue;
+      }
+
+      let sourcePath: string | undefined;
+
+      for (const candidate of targets.map((t) =>
+        join(dirname(t.filePath), fileName),
+      )) {
+        if (await exists(candidate)) {
+          sourcePath = candidate;
+          break;
+        }
+      }
+
+      if (!sourcePath) {
+        missing.push(`${reference.raw} (${target.label})`);
+        continue;
+      }
+
+      jobs.set(fileName, { reference, sourcePath });
+    }
+  }
+
+  // アップロードを 1 件も始める前に、参照先と形式が揃っていることを確かめる
+  if (missing.length > 0) {
+    throw new Error(
+      `参照先のファイルが見つかりません:\n  ${missing.join("\n  ")}`,
+    );
+  }
+
+  if (unsupported.length > 0) {
+    throw new Error(`対応していない形式です:\n  ${unsupported.join("\n  ")}`);
+  }
+
+  if (jobs.size === 0) {
+    log(`アップロードが必要なローカルの画像・動画はありません: ${id}`);
+    return;
+  }
+
+  const workDir = await mkdtemp(join(tmpdir(), "upload-media-"));
+
+  let sequence = nextSequence(
+    targets.map((t) => t.content),
+    slug,
+  );
+
+  try {
+    for (const [fileName, { reference, sourcePath }] of jobs) {
+      const assetName = assetFileName(slug, sequence, reference);
+
+      // 動画は常に H.264 mp4 へ変換する。寸法は remark-video が width / height にする
+      // TIFF などの画像は PNG へ変換する
+      let uploadPath = sourcePath;
+      let size: VideoSize | undefined;
+
+      if (reference.kind === "video") {
+        uploadPath = join(workDir, assetName);
+        await transcodeVideo(sourcePath, uploadPath);
+        size = await probeVideoSize(uploadPath);
+      } else if (needsImageConversion(reference)) {
+        uploadPath = join(workDir, assetName);
+        await convertImageToPng(sourcePath, uploadPath);
+      }
+
+      const before = (await stat(sourcePath)).size;
+      const after = (await stat(uploadPath)).size;
+      const sizes =
+        uploadPath === sourcePath
+          ? formatSize(after)
+          : `${formatSize(before)} -> ${formatSize(after)}`;
+      const detail = size
+        ? ` ${size.width}x${size.height} ${sizes}`
+        : ` ${sizes}`;
+
+      if (dryRun) {
+        log(`[dry-run] ${fileName} -> ${assetName}${detail}`);
+        sequence++;
+        continue;
+      }
+
+      const { url } = await uploadAsset({
+        filePath: uploadPath,
+        fileName: assetName,
+        contentType: contentTypeOf(assetName),
+        title: assetName,
+      });
+
+      // 1 件ずつ「アップロード → 置換 → 削除」を完結させる。
+      // 途中で失敗しても成功分は確定し、再実行は残りだけを処理する。
+      for (const target of targets) {
+        const replaced = replaceReference(target.content, reference, url, size);
+
+        if (replaced !== target.content) {
+          target.content = replaced;
+          await writeFile(target.filePath, replaced, "utf-8");
+        }
+      }
+
+      await unlink(sourcePath);
+
+      log(`${fileName} -> ${assetName}${detail}`);
+      log(`  ${url}`);
+
+      sequence++;
+    }
+  } finally {
+    await rm(workDir, { recursive: true, force: true });
+  }
+
+  if (dryRun) {
+    log(
+      `\n${jobs.size} 件が対象です。--dry-run を外すとアップロードして ${targets
+        .map((t) => t.label)
+        .join(" / ")} の本文を書き換えます。`,
+    );
+  }
+};

--- a/packages/content-management/src/video.ts
+++ b/packages/content-management/src/video.ts
@@ -1,0 +1,64 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const run = promisify(execFile);
+
+export type VideoSize = { width: number; height: number };
+
+/** 記事本文の表示幅は 756px。Retina でも 1512px なので 1280px あれば足りる */
+const MAX_WIDTH = 1280;
+
+export const probeVideoSize = async (filePath: string): Promise<VideoSize> => {
+  const { stdout } = await run("ffprobe", [
+    "-v",
+    "error",
+    "-select_streams",
+    "v:0",
+    "-show_entries",
+    "stream=width,height",
+    "-of",
+    "csv=p=0",
+    filePath,
+  ]);
+
+  const [width, height] = stdout.trim().split(",").map(Number);
+
+  if (!width || !height) {
+    throw new Error(`動画の寸法を取得できませんでした: ${filePath}`);
+  }
+
+  return { width, height };
+};
+
+/**
+ * 常に H.264 の mp4 へ変換する。
+ *
+ * - scale: 記事幅を超える解像度を切り詰める。-2 は偶数に丸めた高さ
+ * - an: GIF の置き換えが目的なので音声は落とす
+ * - faststart: moov atom を先頭に移し、再生開始を早くする
+ * - yuv420p: 画面収録の yuv444p は Safari で再生できないため変換する
+ */
+export const transcodeVideo = async (
+  input: string,
+  output: string,
+): Promise<void> => {
+  await run("ffmpeg", [
+    "-y",
+    "-i",
+    input,
+    "-vf",
+    `scale='min(${MAX_WIDTH},iw)':-2`,
+    "-c:v",
+    "libx264",
+    "-crf",
+    "28",
+    "-preset",
+    "slow",
+    "-an",
+    "-movflags",
+    "+faststart",
+    "-pix_fmt",
+    "yuv420p",
+    output,
+  ]);
+};

--- a/packages/remark-video/src/index.spec.ts
+++ b/packages/remark-video/src/index.spec.ts
@@ -20,7 +20,7 @@ describe("remark-video", () => {
       `!v(https://example.com/video.mp4)`,
     );
     expect(value.toString()).toBe(
-      `<p><video src="https://example.com/video.mp4" controls></video></p>`,
+      `<p><video src="https://example.com/video.mp4" controls preload="metadata" playsinline></video></p>`,
     );
   });
 
@@ -29,7 +29,7 @@ describe("remark-video", () => {
       `Here is a video: !v(https://example.com/video1.mp4) and another: !v(https://example.com/video2.mp4)`,
     );
     expect(value.toString()).toBe(
-      `<p>Here is a video: <video src="https://example.com/video1.mp4" controls></video> and another: <video src="https://example.com/video2.mp4" controls></video></p>`,
+      `<p>Here is a video: <video src="https://example.com/video1.mp4" controls preload="metadata" playsinline></video> and another: <video src="https://example.com/video2.mp4" controls preload="metadata" playsinline></video></p>`,
     );
   });
 
@@ -47,7 +47,7 @@ describe("remark-video", () => {
       `!v(https://example.com/video.mp4?t=30&autoplay=1)`,
     );
     expect(value.toString()).toBe(
-      `<p><video src="https://example.com/video.mp4?t=30&autoplay=1" controls></video></p>`,
+      `<p><video src="https://example.com/video.mp4?t=30&autoplay=1" controls preload="metadata" playsinline></video></p>`,
     );
   });
 
@@ -56,7 +56,7 @@ describe("remark-video", () => {
       `Check out this video: !v(https://example.com/video.mp4) - it's great!`,
     );
     expect(value.toString()).toBe(
-      `<p>Check out this video: <video src="https://example.com/video.mp4" controls></video> - it's great!</p>`,
+      `<p>Check out this video: <video src="https://example.com/video.mp4" controls preload="metadata" playsinline></video> - it's great!</p>`,
     );
   });
 
@@ -99,7 +99,7 @@ describe("remark-video", () => {
       `!v(http://example.com/video.mp4)`,
     );
     expect(value.toString()).toBe(
-      `<p><video src="http://example.com/video.mp4" controls></video></p>`,
+      `<p><video src="http://example.com/video.mp4" controls preload="metadata" playsinline></video></p>`,
     );
   });
 
@@ -108,7 +108,7 @@ describe("remark-video", () => {
       `!v(https://example.com/video.mp4)`,
     );
     expect(value.toString()).toBe(
-      `<p><video src="https://example.com/video.mp4" controls></video></p>`,
+      `<p><video src="https://example.com/video.mp4" controls preload="metadata" playsinline></video></p>`,
     );
   });
 
@@ -117,7 +117,7 @@ describe("remark-video", () => {
       `Valid: !v(https://example.com/video.mp4) Invalid: !v(javascript:alert('xss'))`,
     );
     expect(value.toString()).toBe(
-      `<p>Valid: <video src="https://example.com/video.mp4" controls></video> Invalid: !v(javascript:alert('xss'))</p>`,
+      `<p>Valid: <video src="https://example.com/video.mp4" controls preload="metadata" playsinline></video> Invalid: !v(javascript:alert('xss'))</p>`,
     );
   });
 
@@ -129,5 +129,32 @@ describe("remark-video", () => {
   test("blocks malformed URLs", async () => {
     const { value } = await processor.process(`!v(not-a-valid-url)`);
     expect(value.toString()).toBe(`<p>!v(not-a-valid-url)</p>`);
+  });
+
+  test("adds width and height when dimensions are given", async () => {
+    const { value } = await processor.process(
+      `!v(https://example.com/video.mp4 1280x720)`,
+    );
+    expect(value.toString()).toBe(
+      `<p><video src="https://example.com/video.mp4" width="1280" height="720" controls preload="metadata" playsinline></video></p>`,
+    );
+  });
+
+  test("handles dimensions in a paragraph with other content", async () => {
+    const { value } = await processor.process(
+      `Before: !v(https://example.com/video.mp4 640x480) after.`,
+    );
+    expect(value.toString()).toBe(
+      `<p>Before: <video src="https://example.com/video.mp4" width="640" height="480" controls preload="metadata" playsinline></video> after.</p>`,
+    );
+  });
+
+  test("leaves the pattern untouched when dimensions are malformed", async () => {
+    const { value } = await processor.process(
+      `!v(https://example.com/video.mp4 1280x)`,
+    );
+    expect(value.toString()).toBe(
+      `<p>!v(https://example.com/video.mp4 1280x)</p>`,
+    );
   });
 });

--- a/packages/remark-video/src/index.ts
+++ b/packages/remark-video/src/index.ts
@@ -56,31 +56,51 @@ function escapeHtmlAttribute(unsafe: string): string {
     .replace(/'/g, "&#039;");
 }
 
+/**
+ * `!v(url)` または `!v(url 1280x720)` にマッチする。
+ * 寸法は省略可能だが、指定するとレイアウトシフトを防げるため
+ * アップロード CLI は常に付与する。
+ */
+const videoPattern = /!v\(([^\s)]+)(?:\s+(\d+)x(\d+))?\)/g;
+
+/**
+ * 自動再生はしない。GIF を避ける理由が「読者が停止できない」ことなので、
+ * 自動再生を入れると同じ問題を再生産してしまう。
+ *
+ * - preload="metadata": 本体を先読みせず、先頭フレームだけ見せる
+ * - playsinline: iPhone で再生時にフルスクリーンへ乗っ取られるのを防ぐ
+ */
+function buildVideoTag(
+  rawUrl: string,
+  width?: string,
+  height?: string,
+): string | null {
+  if (!isValidVideoUrl(rawUrl)) {
+    return null;
+  }
+
+  const escapedUrl = escapeHtmlAttribute(decodeHtmlEntities(rawUrl));
+  const size = width && height ? ` width="${width}" height="${height}"` : "";
+
+  return `<video src="${escapedUrl}"${size} controls preload="metadata" playsinline></video>`;
+}
+
 const remarkVideo: Plugin = () => {
   return (tree) => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     visit(tree, "text", (node: any) => {
       if (!node.value) return;
 
-      // Match the pattern !v(url)
-      const videoPattern = /!v\(([^)]+)\)/g;
       const matches = [...node.value.matchAll(videoPattern)];
 
       if (matches.length === 0) return;
 
       // If the text node contains only the video pattern, replace the entire node
       if (matches.length === 1 && node.value.trim() === matches[0][0]) {
-        const rawUrl = matches[0][1];
+        const html = buildVideoTag(matches[0][1], matches[0][2], matches[0][3]);
 
-        // Validate URL for security
-        if (!isValidVideoUrl(rawUrl)) {
-          return; // Skip invalid URLs, leave original text
-        }
-
-        // Decode HTML entities for the final URL and then escape for HTML attributes
-        const decodedUrl = decodeHtmlEntities(rawUrl);
-        const escapedUrl = escapeHtmlAttribute(decodedUrl);
-        const html = `<video src="${escapedUrl}" controls></video>`;
+        // Skip invalid URLs, leave original text
+        if (!html) return;
 
         node.type = "html";
         node.value = html;
@@ -91,17 +111,11 @@ const remarkVideo: Plugin = () => {
       // If there are multiple patterns or mixed content, split the text
       let newValue = node.value;
       for (const match of matches) {
-        const rawUrl = match[1];
+        const html = buildVideoTag(match[1], match[2], match[3]);
 
-        // Validate URL for security
-        if (!isValidVideoUrl(rawUrl)) {
-          continue; // Skip invalid URLs, leave original pattern
-        }
+        // Skip invalid URLs, leave original pattern
+        if (!html) continue;
 
-        // Decode HTML entities for the final URL and then escape for HTML attributes
-        const decodedUrl = decodeHtmlEntities(rawUrl);
-        const escapedUrl = escapeHtmlAttribute(decodedUrl);
-        const html = `<video src="${escapedUrl}" controls></video>`;
         newValue = newValue.replace(match[0], html);
       }
 


### PR DESCRIPTION
## 概要

記事に貼り付けたローカルの画像・動画を Contentful へアップロードし、本文の参照を公開 URL へ置き換える CLI を追加します。

これまでは Zed で画像を貼り付けたあと、その画像を手で Contentful の Web UI にアップロードし、発行された URL を markdown に貼り戻していました。この往復をなくします。

```bash
npm run upload:media -- <記事ID> --dry-run
npm run upload:media -- <記事ID>
```

## 動作

1. `contents/blogPost/<記事ID>.md` と `contents/blogPost/en/<記事ID>.md` の両方を読む
2. ローカル参照を集め、同じファイルは basename で束ねて 1 度だけアップロードする
3. 1 件ずつ「アップロード → 本文の置換 → ローカルファイルの削除」を完結させる
4. アセット名は `<slug>-<連番>` にする。連番は本文の既存 URL を走査して最大値の次から振る

参照先は markdown のあるディレクトリを基準に basename で解決するので、Zed が挿入するパスの形式（`image.png` / `./image.png` / `/blogPost/image.png`）に依存しません。

途中で失敗しても成功分は確定しているため、再実行すると残りだけが処理されます。参照先の欠落と非対応形式は、1 件もアップロードする前に検出して中断します。

## 変換

### 動画

常に H.264 の mp4 へ再エンコードします。

| オプション | 理由 |
| --- | --- |
| `scale='min(1280,iw)':-2` | 記事本文の幅は 756px。Retina でも 1512px なので、2560px の画面収録をそのまま上げるのは無駄になる |
| `-movflags +faststart` | moov atom を先頭へ移し、再生開始を早くする |
| `-pix_fmt yuv420p` | 画面収録は yuv444p になることがあり、そのままだと Safari で再生できない |
| `-an` | GIF の置き換えが目的なので音声は落とす |

2560x1440 / yuv444p / `.mov` を変換して、1280x720 / yuv420p / mp4、`moov` が `mdat` より前、90KB → 33KB になることを確認しています。

### 画像

macOS のクリップボードは `public.tiff` が標準の画像型なので、Zed に貼り付けた画像が `.tiff` で書き出されることがあります。TIFF は無圧縮のため、同じ絵でも PNG の 20 倍以上になります（実測で 14,286 バイト → 316,178 バイト）。`.tiff` / `.tif` / `.bmp` / `.heic` / `.heif` は PNG へ変換してから上げます。変換は可逆で、アルファチャンネルも保たれることを確認しています。

`.png` / `.jpg` / `.jpeg` / `.gif` / `.webp` はそのまま上げます。

## remark-video

`!v(url)` に加えて `!v(url 1280x720)` を受け付け、次を出力するようにしました。

```html
<video src="..." width="1280" height="720" controls preload="metadata" playsinline></video>
```

- **自動再生しない**。GIF を避ける理由が「読者が停止できない」ことなので、自動再生を入れると同じ問題を再生産する
- `width` / `height` はレイアウトシフト対策。属性がない `<video>` は 300x150 で描画されてから実寸へ跳ねる
- `preload="metadata"` は本体を先読みせず先頭フレームだけ見せる
- `playsinline` は iPhone で再生時にフルスクリーンへ乗っ取られるのを防ぐ

`!v()` はこれまで 475 記事中 0 件で未使用だったため、記法の変更による既存記事への影響はありません。

## 叩き忘れのガード

`BlogPostSchema` の `published: true` の枝の `article` に refine を追加しました。公開する記事の本文にローカル参照が残っていたら弾きます。ドラフトのうちは通します。

このスキーマは `loadBlogPost` 経由で `validate` と `update` の両方が通るため、PR で弾かれ、万一すり抜けても merge 時の Contentful 反映で止まります。

既存の日本語 475 件・英語 66 件すべてに当てて、誤検知が 0 件であることを確認しています。

## テスト

`content-management` 115 件、`remark-video` 18 件が通ります。リポジトリ全体の typecheck / lint / test もグリーンです。

## 未検証

**実際の Contentful へのアップロードは実行していません。** space に本物の Asset が作られる副作用があるためです。`uploadAsset` の呼び出しはテストでモックしてあり、その先の `createAssetFromFiles` → `processForAllLocales` → `publish` の経路だけが未検証です。

## 既知の制約

`!v()` のパスに空白を使えません。macOS の画面収録は `画面収録 2026-09-06 11.24.00.mov` のような名前で出力されるため、置く際にリネームが必要です。引用符で囲む記法を足せば対応できますが、今回は入れていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
