### PR TITLE
fix: remark-gfm が自動リンクした URL でも !v() を動画へ変換する

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35776,24 +35776,6 @@
         "vitest": "^1.0.0"
       }
     },
-    "packages/rehype-link-favicon": {
-      "version": "0.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "unified": "^10.1.2"
-      },
-      "devDependencies": {
-        "eslint": "^8.56.0",
-        "eslint-config-custom": "^0.0.0",
-        "rehype-stringify": "^9.0.0",
-        "remark-parse": "^10.0.1",
-        "remark-rehype": "^10.1.0",
-        "rimraf": "^5.0.0",
-        "tsconfig": "^0.0.0",
-        "typescript": "^5.3.3",
-        "vitest": "^3.0.5"
-      }
-    },
     "packages/rehype-alert/node_modules/@vitest/expect": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
@@ -36297,6 +36279,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "packages/rehype-link-favicon": {
+      "version": "0.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "unified": "^10.1.2"
+      },
+      "devDependencies": {
+        "eslint": "^8.56.0",
+        "eslint-config-custom": "^0.0.0",
+        "rehype-stringify": "^9.0.0",
+        "remark-parse": "^10.0.1",
+        "remark-rehype": "^10.1.0",
+        "rimraf": "^5.0.0",
+        "tsconfig": "^0.0.0",
+        "typescript": "^5.3.3",
+        "vitest": "^3.0.5"
+      }
+    },
     "packages/remark-contentful-image": {
       "version": "0.0.0",
       "license": "MIT",
@@ -36359,6 +36359,7 @@
         "eslint-config-custom": "^0.0.0",
         "rehype-stringify": "^9.0.0",
         "remark": "^14.0.2",
+        "remark-gfm": "^3.0.0",
         "remark-html": "^15.0.2",
         "remark-parse": "^10.0.1",
         "remark-rehype": "^10.1.0",

--- a/packages/remark-video/package.json
+++ b/packages/remark-video/package.json
@@ -23,6 +23,7 @@
     "eslint-config-custom": "^0.0.0",
     "rehype-stringify": "^9.0.0",
     "remark": "^14.0.2",
+    "remark-gfm": "^3.0.0",
     "remark-html": "^15.0.2",
     "remark-parse": "^10.0.1",
     "remark-rehype": "^10.1.0",

--- a/packages/remark-video/src/index.spec.ts
+++ b/packages/remark-video/src/index.spec.ts
@@ -1,18 +1,37 @@
 import { describe, test, expect } from "vitest";
 import { unified } from "unified";
 import markdown from "remark-parse";
+import remarkGfm from "remark-gfm";
 import remark2rehype from "remark-rehype";
 import html from "rehype-stringify";
 
 import remarkVideo from ".";
 
-const processor = unified()
-  .use(markdown)
-  .use(remarkVideo)
-  .use(remark2rehype, {
-    allowDangerousHtml: true,
-  })
-  .use(html, { allowDangerousHtml: true });
+const build = (gfm: boolean) => {
+  const base = unified().use(markdown).use(remarkVideo);
+  const parsed = gfm ? base.use(remarkGfm) : base;
+
+  return parsed
+    .use(remark2rehype, { allowDangerousHtml: true })
+    .use(html, { allowDangerousHtml: true });
+};
+
+/**
+ * アプリのパイプラインは remark-gfm を含む。gfm の autolink literal は
+ * micromark の拡張としてパース時に効くため、`!v(https://...)` の URL が
+ * link ノードに変わり、テキストノードが割れる。gfm の有無で出力が変わらない
+ * ことを毎回確かめる。
+ */
+const processor = {
+  process: async (input: string) => {
+    const withGfm = String(await build(true).process(input));
+    const withoutGfm = String(await build(false).process(input));
+
+    expect(withGfm, "gfm の有無で出力が変わっている").toBe(withoutGfm);
+
+    return { value: withGfm };
+  },
+};
 
 describe("remark-video", () => {
   test("converts !v(url) syntax to video element", async () => {
@@ -150,11 +169,41 @@ describe("remark-video", () => {
   });
 
   test("leaves the pattern untouched when dimensions are malformed", async () => {
+    const input = `!v(https://example.com/video.mp4 1280x)`;
+
+    // 動画記法として成立しないので、gfm はこの URL を通常どおり自動リンクする
+    expect(String(await build(false).process(input))).toBe(
+      `<p>!v(https://example.com/video.mp4 1280x)</p>`,
+    );
+    expect(String(await build(true).process(input))).toBe(
+      `<p>!v(<a href="https://example.com/video.mp4">https://example.com/video.mp4</a> 1280x)</p>`,
+    );
+  });
+
+  test("gfm が URL を自動リンクしても動画へ変換する", async () => {
     const { value } = await processor.process(
-      `!v(https://example.com/video.mp4 1280x)`,
+      `!v(https://downloads.ctfassets.net/a/b/c/d.mp4 1280x720)`,
     );
     expect(value.toString()).toBe(
-      `<p>!v(https://example.com/video.mp4 1280x)</p>`,
+      `<p><video src="https://downloads.ctfassets.net/a/b/c/d.mp4" width="1280" height="720" controls preload="metadata" playsinline></video></p>`,
+    );
+  });
+
+  test("gfm ありで寸法なしの動画も変換する", async () => {
+    const { value } = await processor.process(
+      `!v(https://downloads.ctfassets.net/a/b/c/d.mp4)`,
+    );
+    expect(value.toString()).toBe(
+      `<p><video src="https://downloads.ctfassets.net/a/b/c/d.mp4" controls preload="metadata" playsinline></video></p>`,
+    );
+  });
+
+  test("gfm ありで文中に複数あっても変換する", async () => {
+    const { value } = await processor.process(
+      `前 !v(https://example.com/a.mp4 640x480) 中 !v(https://example.com/b.mp4) 後`,
+    );
+    expect(value.toString()).toBe(
+      `<p>前 <video src="https://example.com/a.mp4" width="640" height="480" controls preload="metadata" playsinline></video> 中 <video src="https://example.com/b.mp4" controls preload="metadata" playsinline></video> 後</p>`,
     );
   });
 });

--- a/packages/remark-video/src/index.ts
+++ b/packages/remark-video/src/index.ts
@@ -85,8 +85,60 @@ function buildVideoTag(
   return `<video src="${escapedUrl}"${size} controls preload="metadata" playsinline></video>`;
 }
 
+/**
+ * `!v(` の直後に続く自動リンクの末尾。`)` か ` 1280x720)` にマッチする
+ */
+const AUTOLINKED_TAIL = /^(?:\s+(\d+)x(\d+))?\)/;
+
+const VIDEO_PREFIX = "!v(";
+
+/**
+ * remark-gfm の autolink literal は micromark の拡張としてパース時に効くため、
+ * プラグインの適用順に関係なく `!v(https://...)` の URL が link ノードになり、
+ * テキストノードが `!v(` / link / ` 1280x720)` の 3 つに割れる。
+ * 割れた並びを 1 つの video 要素へ畳み直す。
+ */
+const collapseAutolinkedVideos = (tree: unknown) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  visit(tree as any, (node: any) => {
+    if (!Array.isArray(node.children)) return;
+
+    for (let index = 0; index < node.children.length - 2; index++) {
+      const head = node.children[index];
+      const link = node.children[index + 1];
+      const tail = node.children[index + 2];
+
+      if (
+        head?.type !== "text" ||
+        typeof head.value !== "string" ||
+        !head.value.endsWith(VIDEO_PREFIX)
+      ) {
+        continue;
+      }
+
+      if (link?.type !== "link" || typeof link.url !== "string") continue;
+      if (tail?.type !== "text" || typeof tail.value !== "string") continue;
+
+      const match = AUTOLINKED_TAIL.exec(tail.value);
+
+      if (!match) continue;
+
+      const html = buildVideoTag(link.url, match[1], match[2]);
+
+      // 不正な URL はそのまま残す
+      if (!html) continue;
+
+      head.value = head.value.slice(0, -VIDEO_PREFIX.length);
+      tail.value = tail.value.slice(match[0].length);
+      node.children[index + 1] = { type: "html", value: html };
+    }
+  });
+};
+
 const remarkVideo: Plugin = () => {
   return (tree) => {
+    collapseAutolinkedVideos(tree);
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     visit(tree, "text", (node: any) => {
       if (!node.value) return;


### PR DESCRIPTION
## 問題

アプリ上で `!v()` 記法が変換されず、素のテキストとして表示されていました。

## 原因

`remark-gfm` の autolink literal は **micromark の拡張としてパース時に効く**ため、プラグインの適用順に関係なく `!v(https://...)` の中の URL が `link` ノードになります。その結果、テキストノードが 3 つに割れます。

```
text "!v("  →  link  →  text " 1280x720)"
```

`remark-video` は `visit(tree, "text")` で text ノードだけを見ていたため、割れた断片にはパターンが一致せず、変換されませんでした。

[markdownToHtml.ts](https://github.com/azukiazusa1/sapper-blog-app/blob/main/app/src/lib/server/markdownToHtml.ts) では `.use(remarkVideo)` が `.use(remarkGfm)` より前に置かれていますが、gfm はトランスフォーマではなくパーサを拡張するため、この順序では回避できません。

これは #1574 で入った不具合ではなく以前からあったものです。`!v()` が 475 記事中 0 件で未使用だったため表面化していませんでした。

## 修正

割れた並び（text が `!v(` で終わる → `link` → text が `)` または ` 1280x720)` で始まる）を検出し、1 つの `<video>` 要素へ畳み直します。URL の検証（http / https のみ）は従来どおり通します。

gfm を通さない場合の text ノード経路も残しているので、どちらのパイプラインでも動きます。

## テストの見直し

`remark-video` のテストがアプリと違うパイプライン（`remark-gfm` なし）で書かれていたため、この不具合を検出できていませんでした。

**gfm あり・なしの両方で処理し、出力が一致することを毎回確かめる**ようにしました。今後 gfm 側だけで壊れる変更は必ず落ちます。

```ts
const withGfm = String(await build(true).process(input));
const withoutGfm = String(await build(false).process(input));
expect(withGfm, "gfm の有無で出力が変わっている").toBe(withoutGfm);
```

寸法が壊れていて記法として成立しない入力（`!v(url 1280x)`）だけは、gfm が通常どおり URL を自動リンクするため出力が異なります。これは正しい挙動なので個別に期待値を書いています。

`remark-gfm` を devDependency に追加しました（アプリと同じ `^3.0.0`）。

## 確認

アプリの `markdownToHtml` を実際に通して確認しています。

```
<p><video src="https://downloads.ctfassets.net/.../ime-enter-submit-1.mp4" width="1280" height="720" controls preload="metadata" playsinline></video></p>
```

`remark-video` 21 件が通り、リポジトリ全体の typecheck / lint / test もグリーンです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
